### PR TITLE
Fix update haproxy.cfg file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
         awscli \
     && rm -rf /var/cache/apk/*
 
-COPY haproxy/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+COPY haproxy/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg.tmpl
 COPY entrypoint.sh /entrypoint.sh
 COPY auth_update.sh /auth_update.sh
 

--- a/auth_update.sh
+++ b/auth_update.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 HAPROXY_CFG=/usr/local/etc/haproxy/haproxy.cfg
+HAPROXY_CFG_TEMPLATE=${HAPROXY_CFG}.tmpl
 
 log() {
    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
@@ -44,6 +45,7 @@ fi
 log "Updating config with URL: ${reg_url_clean} and auth token length: ${#auth_n}"
 
 # Update HAProxy config with error checking
+cp ${HAPROXY_CFG_TEMPLATE} ${HAPROXY_CFG}
 if ! sed -i "s|REGISTRY_URL|${reg_url_clean}|g" ${HAPROXY_CFG}; then
    log "Error: Failed to update registry URL in config"
    exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ monitor_haproxy &
 
 # Start auth renewal in background
 (while true; do
-    sleep 6h
+    sleep ${RENEW_INTERVAL:-6h}
     # If auth update fails, log and continue trying
     if ! /auth_update.sh; then
         echo "[$(date '+%Y-%m-%d %H:%M:%S')] Auth update failed, will retry in 5 minutes"


### PR DESCRIPTION
I loved the rewrite to use haproxy instead of nginx, but the renew was broken:
- the initial update did work, it updated the haproxy.cfg file with sed by replacing the template strings `REGISTRY_URL` and `ECR_AUTH_TOKEN`
- for the following updates (after 6h) it was renewing the ecr token correctly but the haproxy.cfg file was never updated
  - for the sed replace to work, the placeholder strings `REGISTRY_URL` and `ECR_AUTH_TOKEN` must be there
  - but since the sed changing the file in place (`-i` flag), after the initial update, those placeholders strings were not longer in the file, so there was nothing to replace
  - after 6h, the "updated" haproxy.cfg file identical and contained the first initial token
  - the same happens on the next updates and after 12h the initial token expires and the proxy ceases to work.

This PR fixes that:
- basically, instead of copying the template haproxy.cfg file (with string placeholders) to the final destination, it copies the file to a template version (`haproxy.cfg.tmpl`)
- upon each update, the template file is restored with the placeholders so the sed substitutions work